### PR TITLE
Allow mappings between chat template parts and input units

### DIFF
--- a/icx360/utils/model_wrappers/huggingface.py
+++ b/icx360/utils/model_wrappers/huggingface.py
@@ -91,9 +91,9 @@ class HFModel(Model):
                     else:
                         messages = [{"role": "user", "content": inputs}]
 
-            # Encode chat
-            input_encoding = self._tokenizer.apply_chat_template(
-                messages, add_generation_prompt=True, return_dict=True, **kwargs).to(self._device)
+                # Encode chat
+                input_encoding = self._tokenizer.apply_chat_template(
+                    messages, add_generation_prompt=True, return_dict=True, **kwargs).to(self._device)
         else:
             # Encode text
             input_encoding = self._tokenizer(inputs, **kwargs).to(self._device)

--- a/icx360/utils/model_wrappers/vllm.py
+++ b/icx360/utils/model_wrappers/vllm.py
@@ -81,6 +81,10 @@ class VLLMModel(Model):
 
                 # Apply chat template
                 inputs = self._tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+        else:
+            if isinstance(inputs, list) and isinstance(inputs[0], list):
+                # Join segmented units
+                inputs = ["".join(inp) for inp in inputs]
 
         return inputs
 

--- a/icx360/utils/scalarizers/prob.py
+++ b/icx360/utils/scalarizers/prob.py
@@ -40,7 +40,9 @@ class ProbScalarizedModel(Scalarizer):
         if not isinstance(model, HFModel) and not isinstance(model, VLLMModel):
             raise TypeError("Model must be a HFModel (HuggingFace) or VLLMModel for ProbScalarizedModel")
 
-    def scalarize_output(self, inputs=None, outputs=None, ref_input=None, ref_output=None, chat_template=False, system_prompt=None, tokenizer_kwargs={}, transformation="log_prob_mean", **kwargs):
+    def scalarize_output(self, inputs=None, outputs=None, ref_input=None, ref_output=None,
+                         chat_template=False, system_prompt=None, unit_ranges=None, tokenizer_kwargs={},
+                         transformation="log_prob_mean", **kwargs):
         """
         Compute probability of generating reference output (or each unit thereof) conditioned on inputs.
 
@@ -58,6 +60,8 @@ class ProbScalarizedModel(Scalarizer):
                 Whether to apply chat template.
             system_prompt (str or None):
                 System prompt to include in chat template.
+            unit_ranges (dict or None):
+                Mapping from chat template parts to ranges of input units.
             tokenizer_kwargs (dict):
                 Additional keyword arguments for tokenizer.
             transformation (str, optional):
@@ -77,7 +81,7 @@ class ProbScalarizedModel(Scalarizer):
         if inputs is None:
             raise ValueError("inputs must be provided for ProbScalarizedModel.scalarize_output()")
         else:
-            inputs = self.model.convert_input(inputs, chat_template, system_prompt, **tokenizer_kwargs)
+            inputs = self.model.convert_input(inputs, chat_template, system_prompt, unit_ranges, **tokenizer_kwargs)
         # Check for reference output
         if ref_output is None:
             raise ValueError("ref_output must be provided for ProbScalarizedModel.scalarize_output()")


### PR DESCRIPTION
### Summary                                                                                                 
                  
Adds a `unit_ranges` parameter to `HFModel`, `VLLMModel`, and `ProbScalarizedModel` to specify mappings from parts of the chat template (conversation turns, documents) to ranges of segmented input units.

  ### Changes

- **`HFModel.convert_input` / `generate`**: Added `unit_ranges` parameter and `_construct_chat_template_from_mapping()` helper that assembles multi-turn conversations and optional context documents from unit index ranges.
- **`VLLMModel.convert_input` / `generate`**: Same `unit_ranges` support and `_construct_chat_template_from_mapping()` helper (mirrors HFModel logic).
- **`ProbScalarizedModel.scalarize_output`**: Passes `unit_ranges` through to `model.convert_input`.